### PR TITLE
Support braceless root objects

### DIFF
--- a/syntaxes/Hjson.tmLanguage
+++ b/syntaxes/Hjson.tmLanguage
@@ -37,17 +37,7 @@
   <array>
     <dict>
       <key>include</key>
-      <string>#comments</string>
-    </dict>
-    <dict>
-      <key>include</key>
-      <string>#value</string>
-    </dict>
-    <dict>
-      <key>match</key>
-      <string>[^\s]</string>
-      <key>name</key>
-      <string>invalid.illegal.excess-characters.hjson</string>
+      <string>#objectContent</string>
     </dict>
   </array>
   <key>repository</key>


### PR DESCRIPTION
Quoting RFC [1]

> A Hjson text is either a serialized value or a root object.
>
>    Hjson-text = ws-c ( root-object / value ) ws-c

Also from "5. Objects" section:

> If the Hjson text defines an object it does not have to include the braces at the root level:
>    root-object =
>             member
>             *( value-separator member ) [value-separator]

See test case [2].

[1] https://hjson.github.io/rfc.html#hjson-grammar
[2] https://github.com/hjson/hjson/blob/49abb794b1e0305e84261fd1bebe20e17dd4626e/testCases/extra/root_test.hjson